### PR TITLE
Fix flickering of viewer content

### DIFF
--- a/GlfwOcctView.cpp
+++ b/GlfwOcctView.cpp
@@ -187,7 +187,7 @@ void GlfwOcctView::initViewer()
     aViewer->SetDefaultTypeOfView(V3d_PERSPECTIVE);
     aViewer->ActivateGrid(Aspect_GT_Rectangular, Aspect_GDM_Lines);
     myView = aViewer->CreateView();
-    myView->SetImmediateUpdate(Standard_False);
+    //myView->SetImmediateUpdate(Standard_False);
     myView->SetWindow(myOcctWindow, myOcctWindow->NativeGlContext());
     myView->ChangeRenderingParams().ToShowStats = Standard_True;
 
@@ -284,6 +284,7 @@ void GlfwOcctView::mainloop()
         glfwWaitEvents();
         if (!myView.IsNull())
         {
+            myView->InvalidateImmediate(); // redraw view even if it wasn't modified
             FlushViewEvents(myContext, myView, Standard_True);
 
             renderGui();
@@ -327,7 +328,8 @@ void GlfwOcctView::onResize(int theWidth, int theHeight)
         myView->Window()->DoResize();
         myView->MustBeResized();
         myView->Invalidate();
-        myView->Redraw();
+        FlushViewEvents(myContext, myView, true);
+        renderGui();
     }
 }
 
@@ -381,7 +383,7 @@ void GlfwOcctView::onMouseMove(int thePosX, int thePosY)
     ImGuiIO& aIO = ImGui::GetIO();
     if (aIO.WantCaptureMouse)
     {
-        myView->Redraw();
+        //myView->Redraw();
     }
     else
     {

--- a/GlfwOcctView.h
+++ b/GlfwOcctView.h
@@ -65,6 +65,10 @@ private:
     //! Clean up before .
     void cleanup();
 
+    //! Handle view redraw.
+    void handleViewRedraw(const Handle(AIS_InteractiveContext)& theCtx,
+                          const Handle(V3d_View)& theView) override;
+
     //! @name GLWF callbacks
 private:
     //! Window resize event.
@@ -123,6 +127,7 @@ private:
     Handle(GlfwOcctWindow) myOcctWindow;
     Handle(V3d_View) myView;
     Handle(AIS_InteractiveContext) myContext;
+    bool myToWaitEvents = true;
 
 };
 


### PR DESCRIPTION
Added invalidation of V3d_View before FlushViewEvents, to ensure that OpenGL backbuffer is updated by 3D Viewer before redrawing ImGUI on top (renderGui())
and swapping GLFW buffers (by glfwSwapBuffers()).

Window resizing now redraws GUI content.

Removed flag V3d_View::SetImmediateUpdate() to allow ImGUI to be redrawn on top of 3D Viewer via lazy update (e.g. on mouse move without changing scene / camera).