### PR TITLE
Render OCCT view into a floating window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.15)
 # Project configuration
 project(OcctImgui LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set output directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
@@ -25,7 +28,22 @@ add_executable(OcctImgui ${SOURCES})
 
 # Link libraries
 target_link_libraries(OcctImgui
-PRIVATE    TKernel TKMath TKG2d TKG3d TKGeomBase TKGeomAlgo TKBRep TKTopAlgo TKPrim TKMesh TKService TKOpenGl TKV3d
+PRIVATE        TKernel
+TKMath
+TKBRep
+TKGeomBase
+TKGeomAlgo
+TKG3d
+TKG2d
+TKShHealing
+TKBO
+TKPrim
+TKTopAlgo
+TKMesh
+TKV3d
+TKLCAF
+TKCAF
+TKOpenGl
   glfw
 )
 
@@ -38,16 +56,4 @@ target_link_directories(OcctImgui PRIVATE
     $<$<CONFIG:Debug>:${DEBUG_LIBS}>
     $<$<CONFIG:Release>:${RELEASE_LIBS}>
 )
-
-# Debug environment variables (for Windows)
-if(WIN32)
-    set(DEBUG_ENVS "path=%path%;D:/OpenCASCADE-7.7.0/opencascade-7.7.0/win64/vc14/bind")
-    set(RELEASE_ENVS "path=%path%;D:/OpenCASCADE-7.7.0/opencascade-7.7.0/win64/vc14/bin")
-
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set_target_properties(OcctImgui PROPERTIES VS_DEBUGGER_ENVIRONMENT "${DEBUG_ENVS}")
-    elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-        set_target_properties(OcctImgui PROPERTIES VS_DEBUGGER_ENVIRONMENT "${RELEASE_ENVS}")
-    endif()
-endif()
 

--- a/GlfwOcctView.h
+++ b/GlfwOcctView.h
@@ -44,6 +44,9 @@ public:
 
 private:
 
+    //! Create Offscreen rendered with a sample scene
+    void initOffScreenRenderer();
+    
     //! Create GLFW window.
     void initWindow(int theWidth, int theHeight, const char* theTitle);
 

--- a/OcctOffscreenViewer.h
+++ b/OcctOffscreenViewer.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <AIS_InteractiveContext.hxx>
+#include <AIS_Shape.hxx>
+#include <AIS_ViewCube.hxx>
+#include <Aspect_DisplayConnection.hxx>
+#include <Aspect_NeutralWindow.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <OpenGl_GraphicDriver.hxx>
+#include <V3d_View.hxx>
+#include <V3d_Viewer.hxx>
+//! Sample offscreen viewer class.
+class OcctOffscreenViewer {
+ public:
+  //! Return view instance.
+  const Handle(V3d_View) & View() const { return myView; }
+
+  //! Return AIS context.
+  const Handle(AIS_InteractiveContext) & Context() const { return myContext; }
+
+  //! Initialize offscreen viewer.
+  //! @param[in] theWinSize view dimensions
+  //! @return FALSE in case of initialization error
+  bool InitOffscreenViewer(const Graphic3d_Vec2i& theWinSize) {
+    try {
+      OCC_CATCH_SIGNALS
+
+      // create graphic driver
+      Handle(Aspect_DisplayConnection) aDispConnection =
+          new Aspect_DisplayConnection();
+      Handle(OpenGl_GraphicDriver) aDriver =
+          new OpenGl_GraphicDriver(aDispConnection, true);
+      aDriver->ChangeOptions().ffpEnable = false;
+      aDriver->ChangeOptions().swapInterval = 0;
+
+      // create viewer and AIS context
+      myViewer = new V3d_Viewer(aDriver);
+      myContext = new AIS_InteractiveContext(myViewer);
+
+      // light sources setup
+      myViewer->SetDefaultLights();
+      myViewer->SetLightOn();
+
+      // create offscreen window
+      const TCollection_AsciiString aWinName("OCCT offscreen window");
+      Handle(Aspect_NeutralWindow) aWindow = new Aspect_NeutralWindow();
+      aWindow->SetSize(theWinSize.x(), theWinSize.y());
+      aWindow->SetVirtual(true);
+
+      // create 3D view from offscreen window
+      myView = new V3d_View(myViewer);
+      myView->SetWindow(aWindow);
+
+      // Display something
+      gp_Pnt cubeCenter(0.0, 0.0, 0.0);
+      TopoDS_Solid cube =
+          BRepPrimAPI_MakeBox(cubeCenter, 1.0, 1.0, 1.0).Solid();
+
+      // Create an AIS_Shape from the result
+      Handle(AIS_Shape) aisShape = new AIS_Shape(cube);
+
+      // Display the shape
+      myContext->Display(aisShape, AIS_Shaded, 0, false);
+    } catch (const Standard_Failure& theErr) {
+      Message::SendFail() << "Offscreen Viewer creation FAILED:\n" << theErr;
+      return false;
+    }
+    return true;
+  }
+
+  //! Print information about graphics context.
+  void DumpGlInfo() {
+    TColStd_IndexedDataMapOfStringString aGlCapsDict;
+    myView->DiagnosticInformation(aGlCapsDict, Graphic3d_DiagnosticInfo_Basic);
+    TCollection_AsciiString anInfo = "OpenGL info:\n";
+    for (TColStd_IndexedDataMapOfStringString::Iterator aValueIter(aGlCapsDict);
+         aValueIter.More(); aValueIter.Next()) {
+      if (!aValueIter.Value().IsEmpty()) {
+        anInfo += TCollection_AsciiString("  ") + aValueIter.Key() + ": " +
+                  aValueIter.Value() + "\n";
+      }
+    }
+    Message::SendInfo(anInfo);
+  }
+
+ private:
+  Handle(V3d_Viewer) myViewer;
+  Handle(V3d_View) myView;
+  Handle(AIS_InteractiveContext) myContext;
+};


### PR DESCRIPTION
I'm trying to expand the example by moving the 3D interactive scene into a floating window. My understanding is that this requires OCC to render into a buffer and then `imgui::Image` (or similar functionality) to render the buffer into the GUI. However I'm getting stuck.

I've imported a new class [adapted from here](https://github.com/gkv311/occt-hello/blob/master/occt-ais-offscreen/OcctAisOffscreen.cpp) OffScreenRenderer. I initialise it but then I get an OpenGL error when I try to render the image into the buffer with `ToPixMap`.

@gkv311 maybe you can help me. Do you know if the error comes from the fact that an application cannot have on-screen and off-screen renderers at the same time? Or perhaps because I'm using a general `Aspect_NeutralWindow` for the off-screen renderer?
